### PR TITLE
Use pcl 1.8 instead of 1.7

### DIFF
--- a/localization.orogen
+++ b/localization.orogen
@@ -1,7 +1,7 @@
 name "localization"
 
-using_library 'pcl_registration-1.7'
-using_library 'pcl_io-1.7'
+using_library 'pcl_registration-1.8'
+using_library 'pcl_io-1.8'
 using_library 'depth_map_preprocessing'
 using_library 'base-logging'
 


### PR DESCRIPTION
Pcl1.8 is the version that gets shipped with Ubuntu 18.04. Should we use it as default version in this package?